### PR TITLE
fix format not a string literal and no format arguments

### DIFF
--- a/lib/xlsxio_write.c
+++ b/lib/xlsxio_write.c
@@ -858,7 +858,7 @@ void write_cell_data (xlsxiowriter handle, const char* rowattr, const char* pref
     if (data)
       fprintf(handle->pipe_write, "%s", data);
     if (suffix)
-      fprintf(handle->pipe_write, suffix);
+      fprintf(handle->pipe_write, "%s", suffix);
   } else {
     //add cell data to buffer
     if (prefix)


### PR DESCRIPTION
```
/dev/shm/BUILD/xlsxio-b2b39b91c5005b4edc78ff8145226338aaea1c2c/lib/xlsxio_write.c: In function 'write_cell_data':
/dev/shm/BUILD/xlsxio-b2b39b91c5005b4edc78ff8145226338aaea1c2c/lib/xlsxio_write.c:857:7: error: format not a string literal and no format arguments [-Werror=format-security]
       fprintf(handle->pipe_write, suffix);
       ^~~~~~~
cc1: some warnings being treated as errors

```