### PR TITLE
fix: C2036: 'void *': unknown size

### DIFF
--- a/lib/xlsxio_read.c
+++ b/lib/xlsxio_read.c
@@ -514,7 +514,7 @@ uLong ZCALLBACK minizip_io_memory_read_file_fn (voidpf opaque, voidpf stream, vo
     len = size;
   else
     len = ((struct minizip_io_memory_data*)opaque)->datalen - ((struct minizip_io_memory_handle*)stream)->pos;
-  memcpy(buf, ((struct minizip_io_memory_data*)opaque)->data + ((struct minizip_io_memory_handle*)stream)->pos, len);
+  memcpy(buf, (char *)(((struct minizip_io_memory_data*)opaque)->data) + ((struct minizip_io_memory_handle*)stream)->pos, len);
   ((struct minizip_io_memory_handle*)stream)->pos += len;
   return len;
 }


### PR DESCRIPTION
`void *` unknown size