### PR TITLE
Compilation and warnings fixes for modern MSVC

### DIFF
--- a/lib/xlsxio_read.c
+++ b/lib/xlsxio_read.c
@@ -1625,7 +1625,7 @@ DLL_EXPORT_XLSXIO int xlsxioread_sheet_next_cell_datetime (xlsxioreadersheet she
     if (value != 0) {
       value = (value - 25569) * 86400;  //conversion from Excel to Unix timestamp
     }
-    *pvalue = value;
+    *pvalue = (time_t)value;
   }
   free(result);
   return 1;

--- a/lib/xlsxio_write.c
+++ b/lib/xlsxio_write.c
@@ -47,7 +47,9 @@ typedef struct zip_source zip_source_t;
 #if defined(_MSC_VER)
 #  undef DLL_EXPORT_XLSXIO
 #  define DLL_EXPORT_XLSXIO
-#  define va_copy(dst,src) ((dst) = (src))
+#  ifndef va_copy
+#    define va_copy(dst,src) ((dst) = (src))
+#  endif
 #endif
 
 #ifdef _WIN32

--- a/src/xlsxio_write_main.c
+++ b/src/xlsxio_write_main.c
@@ -8,7 +8,7 @@ int main (int argc, char* argv[])
   if (argc <= 1)
     return 0;
   unlink(argv[1]);
-  if ((handle = xlsxiowrite_open(argv[1])) == NULL) {
+  if ((handle = xlsxiowrite_open(argv[1], NULL)) == NULL) {
     fprintf(stderr, "Error creating zip file\n");
     return 1;
   }


### PR DESCRIPTION
Fixes warnings emitted by modern versions of MSVC compiler.

(Strictly speaking, 45ff9b1ac75139620c5c18eec78e6c58ce5f0f9e is not specific to MSVC, let me know if you want a separate PR for that.)