### PR TITLE
Add Conan installation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ lib /def:libxlsxio_read.def /out:libxlsxio_read.lib /machine:x64
 lib /def:libxlsxio_readw.def /out:libxlsxio_readw.lib /machine:x64
 ```
 
+Installing XLSX I/O using Conan
+-------------------------------
+
+You can install pre-built binaries for XLSX I/O or build it from source using
+[Conan](https://conan.io/). Use the following command:
+
+```bash
+conan install --requires="xlsxio/[*]" --build=missing
+```
+
+The XLSX I/O Conan recipe is kept up to date by Conan maintainers and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/conan-io/conan-center-index)
+on the ConanCenterIndex repository.
+
 Example C programs
 ------------------
 ### Reading from an .xlsx file


### PR DESCRIPTION
Hello!

This documentation PR is related to #110. As I commented there, there is an official Conan package for XLS I/O available on Conan Center:

```
conan search xlsxio
Connecting to remote 'conancenter' anonymously
Found 2 pkg/version recipes matching xlsxio in conancenter
conancenter
  xlsxio
    xlsxio/0.2.33
    xlsxio/0.2.34
```

The version 0.2.36 is still not available due PR #144, which should fix an important point first, so we can provide a new release in Conan Center. 

The expression `xlsxio/[*]` means `latest` version available, and `--build=missing` is for: Build from source in case not having a pre-built package available.

Please let me know if it's adding it to your README, or if I should move to another place. Regards.