### PR TITLE
add cell type detection and typed cell reading

### DIFF
--- a/include/xlsxio_read.h
+++ b/include/xlsxio_read.h
@@ -162,6 +162,34 @@ DLL_EXPORT_XLSXIO void xlsxioread_list_sheets (xlsxioreader handle, xlsxioread_l
 #define XLSXIOREAD_SKIP_HIDDEN_ROWS     0x08
 /*! @} */
 
+/*! \brief possible values for cell type
+ * \sa     xlsxioread_sheet_next_cell_struct()
+ * \name   XLSXIOREAD_CELL_TYPE_*
+ * \{
+ */
+typedef enum {
+  XLSXIOREAD_CELL_TYPE_NONE,            /*!< \brief unknown or empty cell \hideinitializer */
+  XLSXIOREAD_CELL_TYPE_VALUE,           /*!< \brief numeric value \hideinitializer */
+  XLSXIOREAD_CELL_TYPE_BOOLEAN,         /*!< \brief boolean value \hideinitializer */
+  XLSXIOREAD_CELL_TYPE_STRING,          /*!< \brief string value \hideinitializer */
+  XLSXIOREAD_CELL_TYPE_DATE             /*!< \brief date/time value (stored as number with date format) \hideinitializer */
+} xlsxioread_cell_type;
+/*! @} */
+
+/*! \brief cell data structure returned by xlsxioread_sheet_next_cell_struct()
+ * \sa     xlsxioread_sheet_next_cell_struct()
+ */
+struct xlsxioread_cell_data {
+  size_t row_num;                       /*!< \brief row number (first row is 1) */
+  size_t col_num;                       /*!< \brief column number (first column is 1) */
+  XLSXIOCHAR* data;                     /*!< \brief cell value as string */
+  xlsxioread_cell_type cell_type;       /*!< \brief detected cell type */
+  XLSXIOCHAR* number_fmt;              /*!< \brief number format string (NULL unless numeric/date) */
+};
+
+/*! \brief pointer to cell data structure */
+typedef struct xlsxioread_cell_data* xlsxioread_cell;
+
 /*! \brief type of pointer to callback function for processing a worksheet cell value
  * \param  row           row number (first row is 1)
  * \param  col           column number (first column is 1)
@@ -195,6 +223,31 @@ typedef int (*xlsxioread_process_row_callback_fn)(size_t row, size_t maxcol, voi
  * \sa     xlsxioread_process_cell_callback_fn
  */
 DLL_EXPORT_XLSXIO int xlsxioread_process (xlsxioreader handle, const XLSXIOCHAR* sheetname, unsigned int flags, xlsxioread_process_cell_callback_fn cell_callback, xlsxioread_process_row_callback_fn row_callback, void* callbackdata);
+
+/*! \brief type of pointer to callback function for processing a worksheet cell value with type information
+ * \param  row           row number (first row is 1)
+ * \param  col           column number (first column is 1)
+ * \param  value         value of cell (note: formulas are not calculated)
+ * \param  cell_type     detected cell type
+ * \param  number_fmt    number format string (NULL unless numeric/date)
+ * \param  callbackdata  callback data passed to xlsxioread_process_typed
+ * \return zero to continue, non-zero to abort
+ * \sa     xlsxioread_process_typed()
+ */
+typedef int (*xlsxioread_process_cell_typed_callback_fn)(size_t row, size_t col, const XLSXIOCHAR* value, xlsxioread_cell_type cell_type, const XLSXIOCHAR* number_fmt, void* callbackdata);
+
+/*! \brief process all rows and columns of a worksheet in an .xlsx file with cell type information
+ * \param  handle        read handle for .xlsx object
+ * \param  sheetname     worksheet name (NULL for first sheet)
+ * \param  flags         XLSXIOREAD_SKIP_ flag(s) to determine how data is processed
+ * \param  cell_callback callback function called for each cell (with type information)
+ * \param  row_callback  callback function called after each row
+ * \param  callbackdata  callback data passed to xlsxioread_process_typed
+ * \return zero on success, non-zero on error
+ * \sa     xlsxioread_process_cell_typed_callback_fn
+ * \sa     xlsxioread_process_row_callback_fn
+ */
+DLL_EXPORT_XLSXIO int xlsxioread_process_typed (xlsxioreader handle, const XLSXIOCHAR* sheetname, unsigned int flags, xlsxioread_process_cell_typed_callback_fn cell_callback, xlsxioread_process_row_callback_fn row_callback, void* callbackdata);
 
 
 
@@ -275,6 +328,14 @@ DLL_EXPORT_XLSXIO int xlsxioread_sheet_next_row (xlsxioreadersheet sheethandle);
  */
 DLL_EXPORT_XLSXIO XLSXIOCHAR* xlsxioread_sheet_next_cell (xlsxioreadersheet sheethandle);
 
+/*! \brief get next cell from worksheet with type information
+ * \param  sheethandle   read handle for worksheet object
+ * \return cell data structure (caller must free the result using free()) or NULL if no more cells are available in the current row
+ * \sa     xlsxioread_sheet_open()
+ * \sa     xlsxioread_cell_data
+ */
+DLL_EXPORT_XLSXIO xlsxioread_cell xlsxioread_sheet_next_cell_struct (xlsxioreadersheet sheethandle);
+
 /*! \brief get next cell from worksheet as a string
  * \param  sheethandle   read handle for worksheet object
  * \param  pvalue        pointer where string will be stored if data is available (caller must free the result using xlsxioread_free())
@@ -318,6 +379,12 @@ DLL_EXPORT_XLSXIO int xlsxioread_sheet_next_cell_datetime (xlsxioreadersheet she
  * \sa     xlsxioread_sheet_next_cell_string()
  */
 DLL_EXPORT_XLSXIO void xlsxioread_free (XLSXIOCHAR* data);
+
+/*! \brief print internal styles and number format data for debugging
+ * \param  handle        read handle for .xlsx object
+ * \sa     xlsxioread_open()
+ */
+DLL_EXPORT_XLSXIO void xlsxioread_debug_internals (xlsxioreader handle);
 
 #ifdef __cplusplus
 }

--- a/include/xlsxio_write.h
+++ b/include/xlsxio_write.h
@@ -144,6 +144,13 @@ DLL_EXPORT_XLSXIO void xlsxiowrite_add_cell_int (xlsxiowriter handle, int64_t va
  */
 DLL_EXPORT_XLSXIO void xlsxiowrite_add_cell_float (xlsxiowriter handle, double value);
 
+/*! \brief add a cell with boolean data
+ * \param  handle        write handle for .xlsx object
+ * \param  value         boolean value (0 = false, non-zero = true)
+ * \sa     xlsxiowrite_next_row()
+ */
+DLL_EXPORT_XLSXIO void xlsxiowrite_add_cell_boolean (xlsxiowriter handle, int value);
+
 /*! \brief add a cell with date and time data
  * \param  handle        write handle for .xlsx object
  * \param  value         date and time value

--- a/lib/xlsxio_read.c
+++ b/lib/xlsxio_read.c
@@ -372,14 +372,197 @@ size_t get_row_nr (const XML_Char* A1col)
 
 ////////////////////////////////////////////////////////////////////////
 
+struct xlsxio_number_format {
+  int numFmtId;
+  int is_date;
+  XML_Char* fmt;
+};
+
+struct xlsxio_cell_style {
+  int numFmtId;
+  struct xlsxio_number_format* numfmt;
+};
+
 struct xlsxio_read_struct {
   ZIPFILETYPE* zip;
+  struct xlsxio_cell_style* styles;
+  size_t styles_count;
+  struct xlsxio_number_format* numfmts;
+  size_t numfmts_count;
 };
+
+static void xlsxio_read_struct_init_styles (xlsxioreader handle)
+{
+  handle->styles = NULL;
+  handle->styles_count = 0;
+  handle->numfmts = NULL;
+  handle->numfmts_count = 0;
+}
+
+static int is_date_format (int numFmtId, const XML_Char* fmt)
+{
+  //built-in date format IDs (14-22 are dates/times)
+  if (numFmtId >= 14 && numFmtId <= 22)
+    return 1;
+  //check custom format string for date/time characters
+  if (fmt) {
+    int in_literal = 0;
+    const XML_Char* p;
+    for (p = fmt; *p; p++) {
+      if (*p == '"') {
+        in_literal = !in_literal;
+        continue;
+      }
+      if (*p == '\\') {
+        if (*(p + 1))
+          p++;
+        continue;
+      }
+      if (in_literal)
+        continue;
+      if (*p == 'y' || *p == 'Y' || *p == 'd' || *p == 'D' ||
+          *p == 'h' || *p == 'H' || *p == 's' || *p == 'S')
+        return 1;
+      //m/M can be month (date) or minute (time) - both are date-related
+      if (*p == 'm' || *p == 'M')
+        return 1;
+    }
+  }
+  return 0;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+struct styles_callback_data {
+  XML_Parser xmlparser;
+  //numFmts parsing
+  struct xlsxio_number_format* numfmts;
+  size_t numfmts_count;
+  size_t numfmts_alloc;
+  int in_numFmts;
+  //cellXfs parsing
+  struct xlsxio_cell_style* styles;
+  size_t styles_count;
+  size_t styles_alloc;
+  int in_cellXfs;
+};
+
+static void styles_expat_callback_start (void* callbackdata, const XML_Char* name, const XML_Char** atts);
+static void styles_expat_callback_end (void* callbackdata, const XML_Char* name);
+
+static void styles_expat_callback_start (void* callbackdata, const XML_Char* name, const XML_Char** atts)
+{
+  struct styles_callback_data* data = (struct styles_callback_data*)callbackdata;
+  if (XML_Char_icmp_ins(name, X("numFmts")) == 0) {
+    data->in_numFmts = 1;
+  } else if (XML_Char_icmp_ins(name, X("cellXfs")) == 0) {
+    data->in_cellXfs = 1;
+  } else if (data->in_numFmts && XML_Char_icmp_ins(name, X("numFmt")) == 0) {
+    const XML_Char* numFmtIdStr = get_expat_attr_by_name(atts, X("numFmtId"));
+    const XML_Char* formatCode = get_expat_attr_by_name(atts, X("formatCode"));
+    if (numFmtIdStr) {
+      int numFmtId = (int)XML_Char_tol(numFmtIdStr);
+      //grow array if needed
+      if (data->numfmts_count >= data->numfmts_alloc) {
+        size_t newalloc = (data->numfmts_alloc == 0 ? 16 : data->numfmts_alloc * 2);
+        struct xlsxio_number_format* p = (struct xlsxio_number_format*)realloc(data->numfmts, newalloc * sizeof(struct xlsxio_number_format));
+        if (!p)
+          return;
+        data->numfmts = p;
+        data->numfmts_alloc = newalloc;
+      }
+      data->numfmts[data->numfmts_count].numFmtId = numFmtId;
+      data->numfmts[data->numfmts_count].fmt = (formatCode ? XML_Char_dup(formatCode) : NULL);
+      data->numfmts[data->numfmts_count].is_date = is_date_format(numFmtId, formatCode);
+      data->numfmts_count++;
+    }
+  } else if (data->in_cellXfs && XML_Char_icmp_ins(name, X("xf")) == 0) {
+    const XML_Char* numFmtIdStr = get_expat_attr_by_name(atts, X("numFmtId"));
+    //grow array if needed
+    if (data->styles_count >= data->styles_alloc) {
+      size_t newalloc = (data->styles_alloc == 0 ? 16 : data->styles_alloc * 2);
+      struct xlsxio_cell_style* p = (struct xlsxio_cell_style*)realloc(data->styles, newalloc * sizeof(struct xlsxio_cell_style));
+      if (!p)
+        return;
+      data->styles = p;
+      data->styles_alloc = newalloc;
+    }
+    data->styles[data->styles_count].numFmtId = (numFmtIdStr ? (int)XML_Char_tol(numFmtIdStr) : 0);
+    data->styles[data->styles_count].numfmt = NULL;
+    data->styles_count++;
+  }
+}
+
+static void styles_expat_callback_end (void* callbackdata, const XML_Char* name)
+{
+  struct styles_callback_data* data = (struct styles_callback_data*)callbackdata;
+  if (XML_Char_icmp_ins(name, X("numFmts")) == 0) {
+    data->in_numFmts = 0;
+  } else if (XML_Char_icmp_ins(name, X("cellXfs")) == 0) {
+    data->in_cellXfs = 0;
+  }
+}
+
+static void get_styles (xlsxioreader handle, const XML_Char* stylesfile)
+{
+  if (!stylesfile || !*stylesfile)
+    return;
+  struct styles_callback_data data;
+  data.xmlparser = NULL;
+  data.numfmts = NULL;
+  data.numfmts_count = 0;
+  data.numfmts_alloc = 0;
+  data.in_numFmts = 0;
+  data.styles = NULL;
+  data.styles_count = 0;
+  data.styles_alloc = 0;
+  data.in_cellXfs = 0;
+  expat_process_zip_file(handle->zip, stylesfile, styles_expat_callback_start, styles_expat_callback_end, NULL, &data, &data.xmlparser);
+  //link styles to their number formats
+  size_t i, j;
+  for (i = 0; i < data.styles_count; i++) {
+    //check built-in date formats first (no numFmt entry needed)
+    if (data.styles[i].numFmtId >= 14 && data.styles[i].numFmtId <= 22) {
+      //create a synthetic numfmt entry for built-in date formats if not found
+      for (j = 0; j < data.numfmts_count; j++) {
+        if (data.numfmts[j].numFmtId == data.styles[i].numFmtId) {
+          data.styles[i].numfmt = &data.numfmts[j];
+          break;
+        }
+      }
+      continue;
+    }
+    for (j = 0; j < data.numfmts_count; j++) {
+      if (data.numfmts[j].numFmtId == data.styles[i].numFmtId) {
+        data.styles[i].numfmt = &data.numfmts[j];
+        break;
+      }
+    }
+  }
+  handle->styles = data.styles;
+  handle->styles_count = data.styles_count;
+  handle->numfmts = data.numfmts;
+  handle->numfmts_count = data.numfmts_count;
+}
+
+static void xlsxio_read_free_styles (xlsxioreader handle)
+{
+  if (handle->numfmts) {
+    size_t i;
+    for (i = 0; i < handle->numfmts_count; i++)
+      free(handle->numfmts[i].fmt);
+    free(handle->numfmts);
+  }
+  free(handle->styles);
+}
+
+////////////////////////////////////////////////////////////////////////
 
 DLL_EXPORT_XLSXIO xlsxioreader xlsxioread_open (const char* filename)
 {
   xlsxioreader result;
   if ((result = (xlsxioreader)malloc(sizeof(struct xlsxio_read_struct))) != NULL) {
+    xlsxio_read_struct_init_styles(result);
 #ifdef USE_MINIZIP
     if ((result->zip = unzOpen(filename)) == NULL) {
 #else
@@ -465,6 +648,7 @@ DLL_EXPORT_XLSXIO xlsxioreader xlsxioread_open_filehandle (int filehandle)
 {
   xlsxioreader result;
   if ((result = (xlsxioreader)malloc(sizeof(struct xlsxio_read_struct))) != NULL) {
+    xlsxio_read_struct_init_styles(result);
 #ifdef USE_MINIZIP
     zlib_filefunc_def minizip_io_filehandle_functions;
     if ((minizip_io_filehandle_functions.opaque = malloc(sizeof(struct minizip_io_filehandle_data))) == NULL) {
@@ -606,6 +790,7 @@ DLL_EXPORT_XLSXIO xlsxioreader xlsxioread_open_memory (void* data, uint64_t data
   xlsxioreader result;
 #ifdef USE_MINIZIP
   if ((result = (xlsxioreader)malloc(sizeof(struct xlsxio_read_struct))) != NULL) {
+    xlsxio_read_struct_init_styles(result);
     zlib_filefunc_def minizip_io_memory_functions;
     if ((minizip_io_memory_functions.opaque = malloc(sizeof(struct minizip_io_memory_data))) == NULL) {
       free(result);
@@ -632,6 +817,7 @@ DLL_EXPORT_XLSXIO xlsxioreader xlsxioread_open_memory (void* data, uint64_t data
     return NULL;
   }
   if ((result = (xlsxioreader)malloc(sizeof(struct xlsxio_read_struct))) != NULL) {
+    xlsxio_read_struct_init_styles(result);
     if ((result->zip = zip_open_from_source(zipsrc, ZIP_RDONLY, NULL)) == NULL) {
       zip_source_free(zipsrc);
       free(result);
@@ -645,6 +831,7 @@ DLL_EXPORT_XLSXIO xlsxioreader xlsxioread_open_memory (void* data, uint64_t data
 DLL_EXPORT_XLSXIO void xlsxioread_close (xlsxioreader handle)
 {
   if (handle) {
+    xlsxio_read_free_styles(handle);
     //note: no need to call zip_source_free() after successful use in zip_open_from_source()
 #ifdef USE_MINIZIP
     unzClose(handle->zip);
@@ -917,6 +1104,7 @@ typedef enum {
 struct data_sheet_callback_data {
   XML_Parser xmlparser;
   struct sharedstringlist* sharedstrings;
+  xlsxioreader handle;
   size_t rownr;
   size_t colnr;
   size_t cols;
@@ -924,6 +1112,8 @@ struct data_sheet_callback_data {
   XML_Char* celldata;
   size_t celldatalen;
   cell_string_type_enum cell_string_type;
+  xlsxioread_cell_type cell_type;
+  XML_Char* number_fmt;
   unsigned int flags;
   XML_Char* skiptag;                    //tag to skip
   size_t skiptagcount;                  //nesting level for current tag to skip
@@ -932,13 +1122,15 @@ struct data_sheet_callback_data {
   XML_CharacterDataHandler skip_data;   //data handler to set after skipping
   xlsxioread_process_row_callback_fn sheet_row_callback;
   xlsxioread_process_cell_callback_fn sheet_cell_callback;
+  xlsxioread_process_cell_typed_callback_fn sheet_cell_typed_callback;
   void* callbackdata;
 };
 
-void data_sheet_callback_data_initialize (struct data_sheet_callback_data* data, struct sharedstringlist* sharedstrings, unsigned int flags, xlsxioread_process_cell_callback_fn cell_callback, xlsxioread_process_row_callback_fn row_callback, void* callbackdata)
+void data_sheet_callback_data_initialize (struct data_sheet_callback_data* data, xlsxioreader handle, struct sharedstringlist* sharedstrings, unsigned int flags, xlsxioread_process_cell_callback_fn cell_callback, xlsxioread_process_row_callback_fn row_callback, void* callbackdata)
 {
   data->xmlparser = NULL;
   data->sharedstrings = sharedstrings;
+  data->handle = handle;
   data->rownr = 0;
   data->colnr = 0;
   data->cols = 0;
@@ -946,6 +1138,8 @@ void data_sheet_callback_data_initialize (struct data_sheet_callback_data* data,
   data->celldata = NULL;
   data->celldatalen = 0;
   data->cell_string_type = none;
+  data->cell_type = XLSXIOREAD_CELL_TYPE_NONE;
+  data->number_fmt = NULL;
   data->flags = flags;
   data->skiptag = NULL;
   data->skiptagcount = 0;
@@ -954,6 +1148,7 @@ void data_sheet_callback_data_initialize (struct data_sheet_callback_data* data,
   data->skip_data = NULL;
   data->sheet_cell_callback = cell_callback;
   data->sheet_row_callback = row_callback;
+  data->sheet_cell_typed_callback = NULL;
   data->callbackdata = callbackdata;
 }
 
@@ -1153,10 +1348,49 @@ void data_sheet_expat_callback_find_cell_start (void* callbackdata, const XML_Ch
       }
     }
     //determine value type
-    if ((t = get_expat_attr_by_name(atts, X("t"))) != NULL && XML_Char_icmp(t, X("s")) == 0)
-      data->cell_string_type = shared_string;
-    else
+    data->cell_type = XLSXIOREAD_CELL_TYPE_NONE;
+    data->number_fmt = NULL;
+    t = get_expat_attr_by_name(atts, X("t"));
+    if (t != NULL) {
+      if (XML_Char_icmp(t, X("s")) == 0) {
+        data->cell_string_type = shared_string;
+        data->cell_type = XLSXIOREAD_CELL_TYPE_STRING;
+      } else if (XML_Char_icmp(t, X("str")) == 0 || XML_Char_icmp(t, X("inlineStr")) == 0) {
+        data->cell_string_type = value_string;
+        data->cell_type = XLSXIOREAD_CELL_TYPE_STRING;
+      } else if (XML_Char_icmp(t, X("b")) == 0) {
+        data->cell_string_type = value_string;
+        data->cell_type = XLSXIOREAD_CELL_TYPE_BOOLEAN;
+      } else {
+        //t="n" (number) or other
+        data->cell_string_type = value_string;
+        data->cell_type = XLSXIOREAD_CELL_TYPE_VALUE;
+      }
+    } else {
+      //no type attribute: check style for date detection
       data->cell_string_type = value_string;
+      data->cell_type = XLSXIOREAD_CELL_TYPE_VALUE;
+      {
+        const XML_Char* s = get_expat_attr_by_name(atts, X("s"));
+        if (s && data->handle && data->handle->styles) {
+          long style_idx = XML_Char_tol(s);
+          if (style_idx >= 0 && (size_t)style_idx < data->handle->styles_count) {
+            struct xlsxio_cell_style* style = &data->handle->styles[style_idx];
+            //check built-in date formats
+            if (style->numFmtId >= 14 && style->numFmtId <= 22) {
+              data->cell_type = XLSXIOREAD_CELL_TYPE_DATE;
+              if (style->numfmt && style->numfmt->fmt)
+                data->number_fmt = style->numfmt->fmt;
+            } else if (style->numfmt) {
+              if (style->numfmt->is_date) {
+                data->cell_type = XLSXIOREAD_CELL_TYPE_DATE;
+              }
+              data->number_fmt = style->numfmt->fmt;
+            }
+          }
+        }
+      }
+    }
     //prepare empty value data
     free(data->celldata);
     data->celldata = NULL;
@@ -1198,22 +1432,34 @@ void data_sheet_expat_callback_find_cell_end (void* callbackdata, const XML_Char
       if (!((data->flags & XLSXIOREAD_SKIP_EXTRA_CELLS) && data->cols > 0 && data->colnr > data->cols)) {
         //process data
         if (!(data->flags & XLSXIOREAD_NO_CALLBACK)) {
-          if (data->sheet_cell_callback) {
+          if (data->sheet_cell_callback || data->sheet_cell_typed_callback) {
             //insert empty columns if needed in case of empty row detection
             /////if ((data->flags & XLSXIOREAD_SKIP_EMPTY_ROWS) && !(data->flags & XLSXIOREAD_SKIP_EMPTY_CELLS) && data->colsnotnull == 0 && data->colnr > 1) {
             if (!(data->flags & XLSXIOREAD_SKIP_EMPTY_CELLS) && data->colsnotnull == 0 && data->colnr > 1) {
               size_t col;
               for (col = 1; col < data->colnr; col++) {
-                if ((*data->sheet_cell_callback)(data->rownr, col, NULL, data->callbackdata)) {
+                int abort = 0;
+                if (data->sheet_cell_callback)
+                  abort = (*data->sheet_cell_callback)(data->rownr, col, NULL, data->callbackdata);
+                if (!abort && data->sheet_cell_typed_callback)
+                  abort = (*data->sheet_cell_typed_callback)(data->rownr, col, NULL, XLSXIOREAD_CELL_TYPE_NONE, NULL, data->callbackdata);
+                if (abort) {
                   XML_StopParser(data->xmlparser, XML_FALSE);
                   return;
                 }
               }
             }
             //process current column data
-            if ((*data->sheet_cell_callback)(data->rownr, data->colnr, data->celldata, data->callbackdata)) {
-              XML_StopParser(data->xmlparser, XML_FALSE);
-              return;
+            {
+              int abort = 0;
+              if (data->sheet_cell_callback)
+                abort = (*data->sheet_cell_callback)(data->rownr, data->colnr, data->celldata, data->callbackdata);
+              if (!abort && data->sheet_cell_typed_callback)
+                abort = (*data->sheet_cell_typed_callback)(data->rownr, data->colnr, data->celldata, data->cell_type, data->number_fmt, data->callbackdata);
+              if (abort) {
+                XML_StopParser(data->xmlparser, XML_FALSE);
+                return;
+              }
             }
             data->colsnotnull++;
           }
@@ -1339,17 +1585,22 @@ DLL_EXPORT_XLSXIO int xlsxioread_process (xlsxioreader handle, const XLSXIOCHAR*
     shared_strings_callback_data_cleanup(&sharedstringsdata);
   }
 
+  //process styles (only on first call)
+  if (!handle->styles && !handle->numfmts) {
+    get_styles(handle, getrelscallbackdata.stylesfile);
+  }
+
   //process sheet
   if (!(flags & XLSXIOREAD_NO_CALLBACK)) {
     //use callback mechanism
     struct data_sheet_callback_data processcallbackdata;
-    data_sheet_callback_data_initialize(&processcallbackdata, sharedstrings, flags, cell_callback, row_callback, callbackdata);
+    data_sheet_callback_data_initialize(&processcallbackdata, handle, sharedstrings, flags, cell_callback, row_callback, callbackdata);
     expat_process_zip_file(handle->zip, getrelscallbackdata.sheetfile, data_sheet_expat_callback_find_worksheet_start, NULL, NULL, &processcallbackdata, &processcallbackdata.xmlparser);
     data_sheet_callback_data_cleanup(&processcallbackdata);
   } else {
     //use simplified interface by suspending the XML parser when data is found
     xlsxioreadersheet sheethandle = (xlsxioreadersheet)callbackdata;
-    data_sheet_callback_data_initialize(&sheethandle->processcallbackdata, sharedstrings, flags, NULL, NULL, sheethandle);
+    data_sheet_callback_data_initialize(&sheethandle->processcallbackdata, handle, sharedstrings, flags, NULL, NULL, sheethandle);
     if ((sheethandle->zipfile = XML_Char_openzip(sheethandle->handle->zip, getrelscallbackdata.sheetfile, 0)) == NULL) {
       result = 1;
     }
@@ -1579,6 +1830,36 @@ DLL_EXPORT_XLSXIO XLSXIOCHAR* xlsxioread_sheet_next_cell (xlsxioreadersheet shee
   return result;
 }
 
+DLL_EXPORT_XLSXIO xlsxioread_cell xlsxioread_sheet_next_cell_struct (xlsxioreadersheet sheethandle)
+{
+  XML_Char* value;
+  xlsxioread_cell cell;
+  if (!sheethandle)
+    return NULL;
+  //save parser column before call to detect padding cells
+  size_t parser_colnr_before = sheethandle->processcallbackdata.colnr;
+  size_t lastcolnr_before = sheethandle->lastcolnr;
+  if ((value = xlsxioread_sheet_next_cell(sheethandle)) == NULL)
+    return NULL;
+  if ((cell = (xlsxioread_cell)malloc(sizeof(struct xlsxioread_cell_data))) == NULL) {
+    free(value);
+    return NULL;
+  }
+  cell->row_num = sheethandle->lastrownr ? sheethandle->lastrownr : sheethandle->processcallbackdata.rownr;
+  cell->col_num = sheethandle->lastcolnr;
+  cell->data = value;
+  //determine if this was a padding cell (parser didn't advance)
+  if (sheethandle->processcallbackdata.colnr == parser_colnr_before && sheethandle->lastcolnr != parser_colnr_before) {
+    //padding cell - empty cell inserted for alignment
+    cell->cell_type = XLSXIOREAD_CELL_TYPE_NONE;
+    cell->number_fmt = NULL;
+  } else {
+    cell->cell_type = sheethandle->processcallbackdata.cell_type;
+    cell->number_fmt = (sheethandle->processcallbackdata.number_fmt ? XML_Char_dup(sheethandle->processcallbackdata.number_fmt) : NULL);
+  }
+  return cell;
+}
+
 DLL_EXPORT_XLSXIO int xlsxioread_sheet_next_cell_string (xlsxioreadersheet sheethandle, XLSXIOCHAR** pvalue)
 {
   XML_Char* result;
@@ -1637,4 +1918,110 @@ DLL_EXPORT_XLSXIO int xlsxioread_sheet_next_cell_datetime (xlsxioreadersheet she
 DLL_EXPORT_XLSXIO void xlsxioread_free (XLSXIOCHAR* data)
 {
   free(data);
+}
+
+DLL_EXPORT_XLSXIO int xlsxioread_process_typed (xlsxioreader handle, const XLSXIOCHAR* sheetname, unsigned int flags, xlsxioread_process_cell_typed_callback_fn cell_callback, xlsxioread_process_row_callback_fn row_callback, void* callbackdata)
+{
+  int result = 0;
+  //determine sheet file name
+  struct main_sheet_get_rels_callback_data getrelscallbackdata = {
+    .sheetname = sheetname,
+    .basepath = NULL,
+    .sheetrelid = NULL,
+    .sheetfile = NULL,
+    .sharedstringsfile = NULL,
+    .stylesfile = NULL
+  };
+  iterate_files_by_contenttype(handle->zip, xlsx_content_type, main_sheet_get_sheetfile_callback, &getrelscallbackdata, NULL);
+  if (!getrelscallbackdata.sheetrelid)
+    iterate_files_by_contenttype(handle->zip, xlsm_content_type, main_sheet_get_sheetfile_callback, &getrelscallbackdata, NULL);
+  if (!getrelscallbackdata.sheetrelid)
+    iterate_files_by_contenttype(handle->zip, xltx_content_type, main_sheet_get_sheetfile_callback, &getrelscallbackdata, NULL);
+  if (!getrelscallbackdata.sheetrelid)
+    iterate_files_by_contenttype(handle->zip, xltm_content_type, main_sheet_get_sheetfile_callback, &getrelscallbackdata, NULL);
+
+  //process shared strings
+  struct sharedstringlist* sharedstrings = NULL;
+  if (getrelscallbackdata.sharedstringsfile && getrelscallbackdata.sharedstringsfile[0]) {
+    sharedstrings = sharedstringlist_create();
+    struct shared_strings_callback_data sharedstringsdata;
+    shared_strings_callback_data_initialize(&sharedstringsdata, sharedstrings);
+    if (expat_process_zip_file(handle->zip, getrelscallbackdata.sharedstringsfile, shared_strings_callback_find_sharedstringtable_start, NULL, NULL, &sharedstringsdata, &sharedstringsdata.xmlparser) != 0) {
+      sharedstringlist_destroy(sharedstrings);
+      sharedstrings = NULL;
+    }
+    shared_strings_callback_data_cleanup(&sharedstringsdata);
+  }
+
+  //process styles (only on first call)
+  if (!handle->styles && !handle->numfmts) {
+    get_styles(handle, getrelscallbackdata.stylesfile);
+  }
+
+  //process sheet with typed callback
+  {
+    struct data_sheet_callback_data processcallbackdata;
+    data_sheet_callback_data_initialize(&processcallbackdata, handle, sharedstrings, flags, NULL, row_callback, callbackdata);
+    processcallbackdata.sheet_cell_typed_callback = cell_callback;
+    expat_process_zip_file(handle->zip, getrelscallbackdata.sheetfile, data_sheet_expat_callback_find_worksheet_start, NULL, NULL, &processcallbackdata, &processcallbackdata.xmlparser);
+    data_sheet_callback_data_cleanup(&processcallbackdata);
+  }
+
+  //clean up
+  free(getrelscallbackdata.basepath);
+  free(getrelscallbackdata.sheetrelid);
+  free(getrelscallbackdata.sheetfile);
+  free(getrelscallbackdata.sharedstringsfile);
+  free(getrelscallbackdata.stylesfile);
+  return result;
+}
+
+DLL_EXPORT_XLSXIO void xlsxioread_debug_internals (xlsxioreader handle)
+{
+  size_t i;
+  if (!handle) {
+    printf("xlsxioread_debug_internals: NULL handle\n");
+    return;
+  }
+  //ensure styles are loaded
+  if (!handle->styles && !handle->numfmts) {
+    struct main_sheet_get_rels_callback_data getrelscallbackdata = {
+      .sheetname = NULL,
+      .basepath = NULL,
+      .sheetrelid = NULL,
+      .sheetfile = NULL,
+      .sharedstringsfile = NULL,
+      .stylesfile = NULL
+    };
+    iterate_files_by_contenttype(handle->zip, xlsx_content_type, main_sheet_get_sheetfile_callback, &getrelscallbackdata, NULL);
+    if (!getrelscallbackdata.sheetrelid)
+      iterate_files_by_contenttype(handle->zip, xlsm_content_type, main_sheet_get_sheetfile_callback, &getrelscallbackdata, NULL);
+    if (!getrelscallbackdata.sheetrelid)
+      iterate_files_by_contenttype(handle->zip, xltx_content_type, main_sheet_get_sheetfile_callback, &getrelscallbackdata, NULL);
+    if (!getrelscallbackdata.sheetrelid)
+      iterate_files_by_contenttype(handle->zip, xltm_content_type, main_sheet_get_sheetfile_callback, &getrelscallbackdata, NULL);
+    get_styles(handle, getrelscallbackdata.stylesfile);
+    free(getrelscallbackdata.basepath);
+    free(getrelscallbackdata.sheetrelid);
+    free(getrelscallbackdata.sheetfile);
+    free(getrelscallbackdata.sharedstringsfile);
+    free(getrelscallbackdata.stylesfile);
+  }
+  printf("=== Number Formats (%zu) ===\n", handle->numfmts_count);
+  for (i = 0; i < handle->numfmts_count; i++) {
+    printf("  numFmtId=%d is_date=%d fmt=%s\n",
+           handle->numfmts[i].numFmtId,
+           handle->numfmts[i].is_date,
+           handle->numfmts[i].fmt ? handle->numfmts[i].fmt : "(null)");
+  }
+  printf("=== Cell Styles (%zu) ===\n", handle->styles_count);
+  for (i = 0; i < handle->styles_count; i++) {
+    printf("  [%zu] numFmtId=%d", i, handle->styles[i].numFmtId);
+    if (handle->styles[i].numfmt) {
+      printf(" -> is_date=%d fmt=%s",
+             handle->styles[i].numfmt->is_date,
+             handle->styles[i].numfmt->fmt ? handle->styles[i].numfmt->fmt : "(null)");
+    }
+    printf("\n");
+  }
 }

--- a/lib/xlsxio_write.c
+++ b/lib/xlsxio_write.c
@@ -1051,6 +1051,11 @@ DLL_EXPORT_XLSXIO void xlsxiowrite_add_cell_float (xlsxiowriter handle, double v
   write_cell_data(handle, NULL, "<c" STYLE_ATTR(STYLE_GENERAL) COLNRTAG "><v>", "</v></c>", "%.32G", value);
 }
 
+DLL_EXPORT_XLSXIO void xlsxiowrite_add_cell_boolean (xlsxiowriter handle, int value)
+{
+  write_cell_data(handle, NULL, "<c t=\"b\"" STYLE_ATTR(STYLE_GENERAL) COLNRTAG "><v>", "</v></c>", "%d", (value ? 1 : 0));
+}
+
 DLL_EXPORT_XLSXIO void xlsxiowrite_add_cell_datetime (xlsxiowriter handle, time_t value)
 {
   double timestamp = ((double)(value) + .499) / 86400 + 25569; //conversion from Unix to Excel timestamp


### PR DESCRIPTION
finish the work or dead PR #47

Add support for detecting and retrieving cell types when reading Excel files, including numeric, boolean, string, and date/time values with number format information. Includes new enum for cell types, cell data structure, typed callback function, and new API functions for accessing type information.

