### PR TITLE
Fix segfault in <Default> branch of iterate_files_by_contenttype (#28)

### DIFF
--- a/lib/xlsxio_read.c
+++ b/lib/xlsxio_read.c
@@ -684,6 +684,17 @@ void iterate_files_by_contenttype_expat_callback_element_start (void* callbackda
     }
   } else if (XML_Char_icmp_ins(name, X("Default")) == 0) {
     //by extension
+    // NOTE: expat_process_zip_file has already opened [Content_Types].xml via
+    // unzOpenCurrentFile and is streaming it when this callback runs. On the
+    // minizip backend the code below traverses the zip central directory
+    // (unzGoToFirstFile / unzGetCurrentFileInfo / unzGoToNextFile) on the same
+    // unzFile handle, which corrupts minizip's single state machine and crashes
+    // in unzGetCurrentFileInfo (issue #28). Legitimate xlsx files always declare
+    // the main/sheet content type via <Override>, never <Default>, so this branch
+    // never matches for the content types xlsxio looks up. Skip it on the minizip
+    // backend at compile time; the libzip backend (index-based zip_get_name) is
+    // unaffected and keeps its original logic.
+#ifndef USE_MINIZIP
     const XML_Char* contenttype;
     const XML_Char* extension;
     if ((contenttype = get_expat_attr_by_name(atts, X("ContentType"))) != NULL && XML_Char_icmp(contenttype, data->contenttype) == 0) {
@@ -731,6 +742,7 @@ unzGetGlobalInfo(data->zip, &zipglobalinfo);
 #endif
       }
     }
+#endif /* !USE_MINIZIP: skip <Default> branch to avoid minizip state clash */
   }
 }
 


### PR DESCRIPTION
In iterate_files_by_contenttype_expat_callback_element_start, the <Default> branch traverses the zip central directory (unzGoToFirstFile / unzGetCurrentFileInfo / unzGoToNextFile) inside an expat callback, while expat_process_zip_file has already opened [Content_Types].xml with unzOpenCurrentFile and is streaming it. minizip's unzFile is a single state machine; reentering it for directory traversal corrupts the open-file state and crashes in unzGetCurrentFileInfo.

Legitimate xlsx files always declare the main/sheet content type via <Override>, never <Default>, so this branch never matches for the content types xlsxio looks up. Guard it with #ifndef USE_MINIZIP so the minizip backend skips it at compile time; the libzip backend (index-based zip_get_name) is unaffected.

Fixes #28